### PR TITLE
add 1 retry to help mitigate issue #49 flaky cypress tests

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,6 @@
 {
   "baseUrl": "https://test-slides.surge.sh",
   "video": false,
-  "screenshotOnRunFailure": false
+  "screenshotOnRunFailure": false,
+  "retries": 1
 }


### PR DESCRIPTION
# Problem/Need:

fix #49

# Suggested changes:

Simply added `"retries": 1` as per [recommendation to use intelligent retries](https://docs.cypress.io/guides/dashboard/flaky-test-management.html) and going for simply [adding a global retry](https://docs.cypress.io/guides/guides/test-retries.html#Configure-Test-Retries).

# Checklist:

- [x] ran cypress tests locally with `npx cypress open`
- [ ] after this PR is approved/merged, don't forget to:
  - [ ] have the semver version updated as needed
  - [ ] have the live/prod site updated
