### PR TITLE
smarter test scripts - temp fix #77

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,5 +15,3 @@
 - [ ] after this PR is approved/merged, don't forget to:
   - [ ] have the semver version updated as needed
   - [ ] have the live/prod site updated
-
-(Note: If you don't have write permissions to the surge.sh sites, disable the husky pre-commit hook in package.json, but don't check in that line change in package.json)

--- a/bash-scripts/publish.sh
+++ b/bash-scripts/publish.sh
@@ -15,17 +15,14 @@ cp index.html to-publish
 cp slides.css to-publish
 cp slides.js to-publish
 
-read -p "Are you @hchiam? (y/n) " input
-
-# TODO: change this code to detect surge permissions and run parcel locally
-
-if [[ -z "$input" ]] || [[ $input == "y" ]]
+if surge to-publish https://hchiam-slides.surge.sh && surge to-publish https://simple-slides.surge.sh
 then
-  surge to-publish https://hchiam-slides.surge.sh
-  surge to-publish https://simple-slides.surge.sh
+  echo
+  echo "Published."
+  echo
 else
+  # TODO: run test site locally with parcel
   echo
-  echo "Editing your package.json to disable the pre-commit script (commenting it out with a # character)."
+  echo "Can't publish to live site(s). Consider running test site locally with parcel."
   echo
-  sed -i '' 's/"test-pre-commit":\ "/"test-pre-commit":\ "#/g' package.json
 fi

--- a/bash-scripts/setup-test-site.sh
+++ b/bash-scripts/setup-test-site.sh
@@ -15,16 +15,14 @@ cp index.html to-publish
 cp slides.css to-publish
 cp slides.js to-publish
 
-read -p "Are you @hchiam? (y/n) " input
-
-# TODO: change this code to detect surge permissions and run parcel locally
-
-if [[ -z "$input" ]] || [[ $input == "y" ]]
+if surge to-publish https://test-slides.surge.sh
 then
-  surge to-publish https://test-slides.surge.sh
+  echo
+  echo "Updated test site."
+  echo
 else
+  # TODO: run test site locally with parcel
   echo
-  echo "Editing your package.json to disable the pre-commit script (commenting it out with a # character)."
+  echo "Can't update test site. Consider running test site locally with parcel."
   echo
-  sed -i '' 's/"test-pre-commit":\ "/"test-pre-commit":\ "#/g' package.json
 fi


### PR DESCRIPTION
# Problem/Need:

fix #77

# Suggested changes:

Replace the prompt with automatic detection of publishing permissions. Also fixes travis ci tests so they can complete.

# Checklist:

- [ ] ~ran cypress tests locally with `npx cypress open`~
- [ ] ~ran lighthouse site quality test locally with `yarn test-quality`~
- [ ] ~updated package.json version it'd bump up to if approved~
- [ ] ~updated package-lock.json version it'd bump up to if approved~
- [ ] ~after this PR is approved/merged, don't forget to:~
  - [ ] ~have the semver version updated as needed~
  - [ ] ~have the live/prod site updated~

:) Won't need this reminder anymore soon: (Note: If you don't have write permissions to the surge.sh sites, disable the husky pre-commit hook in package.json, but don't check in that line change in package.json) :)
